### PR TITLE
Update build environment

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,4 @@
 [build-system]
 requires = ["setuptools", "wheel", "cython"]
+build-backend = "setuptools.build_meta"
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,6 +13,7 @@ classifiers =
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
 
 [options]
 packages = find:

--- a/tox.ini
+++ b/tox.ini
@@ -36,9 +36,13 @@ source = src/pyminimp3
 skip_covered = True
 show_missing = True
 
-[testenv:docs]
+[testenv:build]
 description = invoke sphinx-build to build the HTML docs, check that URIs are valid
 basepython = python3.7
-deps = -r docs/requirements-docs.txt
-       {[testenv]deps}
-commands = python setup.py check -r -s
+deps =
+    {[testenv]deps}
+    pep517
+    twine
+commands =
+    python -m pep517.build -s -b {toxinidir} -o {envtmpdir}/dist
+    twine check {envtmpdir}/dist/*


### PR DESCRIPTION
This adds the Python 3.8 classifier, adds the PEP 517 build backend and adds a "build" environment to `tox.ini`.