### PR TITLE
Update submodule URL

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "minimp3"]
 	path = minimp3
-	url = git@github.com:lieff/minimp3.git
+	url = https://github.com/lieff/minimp3.git


### PR DESCRIPTION
Github requires authorization to pull the SSH URL, whereas the HTTPS URL should work without authorization. This will make it easier to pip install from github and should make it so that Travis can properly clone the repo and all submodules.

Fixes issue #1.